### PR TITLE
Fix call expression emitter

### DIFF
--- a/GrobExp.Compiler.Tests/TestExtensionMethod.cs
+++ b/GrobExp.Compiler.Tests/TestExtensionMethod.cs
@@ -49,6 +49,25 @@ namespace GrobExp.Compiler.Tests
             Assert.AreEqual(9, f(new[] {3}));
         }
 
+        /// <summary>
+        /// Test validates that null reference check not applied to the first argument of an extension method
+        /// </summary>
+        [Test]
+        public void TestNullTargetArgument()
+        {
+            Expression<Func<Zurg, bool>> exp = zurg => zurg.IsNull();
+            Func<Zurg, bool> compiledExp = LambdaCompiler.Compile(exp, CompilerOptions.All);
+            Assert.That(compiledExp(null), Is.EqualTo(true));
+            Assert.That(compiledExp(new Zurg()), Is.EqualTo(false));
+        }
+
+        [Test]
+        public void TestRefParameters()
+        {
+            Expression<Func<Zurg, int, int, int>> exp = (o, i, j) => o.Nonsense(ref i, j) ? -1 : j;
+            Func<Zurg, int, int, int> compiledExp = LambdaCompiler.Compile(exp, CompilerOptions.All);
+            Assert.That(compiledExp(new Zurg {Length = 1}, 1, 2), Is.EqualTo(2));
+        }
     }
 
     public enum Zerg
@@ -64,6 +83,11 @@ namespace GrobExp.Compiler.Tests
         Lurker = 9
     }
 
+    public class Zurg
+    {
+        public int Length { get; set; }
+    }
+
     public static class ZergExtensions
     {
         public static bool Flies(this Zerg zerg)
@@ -74,6 +98,20 @@ namespace GrobExp.Compiler.Tests
         public static bool AttacksAir(this Zerg? zerg)
         {
             return zerg == Zerg.Hydralisk || zerg == Zerg.Mutalisk || zerg == Zerg.Devourer;
+        }
+    }
+
+    public static class ZurgExtensions
+    {
+        public static bool IsNull(this Zurg zurg)
+        {
+            return zurg == null;
+        }
+
+        public static bool Nonsense(this Zurg zurg, ref int a, int b)
+        {
+            a = zurg.Length;
+            return a == b;
         }
     }
 }

--- a/GrobExp.Compiler/ExpressionEmitters/CallExpressionEmitter.cs
+++ b/GrobExp.Compiler/ExpressionEmitters/CallExpressionEmitter.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 using GrEmit;
@@ -18,21 +19,25 @@ namespace GrobExp.Compiler.ExpressionEmitters
             var method = node.Method;
             Expression obj;
             IEnumerable<Expression> arguments;
+            IEnumerable<ParameterInfo> parameters;
             bool isStatic = method.IsStatic;
             if(!isStatic)
             {
                 obj = node.Object;
                 arguments = node.Arguments;
+                parameters = method.GetParameters();
             }
-            else if(method.GetCustomAttributes(typeof(ExtensionAttribute), false).Any())
+            else if(method.DeclaringType == typeof(Enumerable))
             {
                 obj = node.Arguments[0];
                 arguments = node.Arguments.Skip(1);
+                parameters = method.GetParameters().Skip(1);
             }
             else
             {
                 obj = null;
                 arguments = node.Arguments;
+                parameters = method.GetParameters();
             }
             Type type = obj == null ? null : obj.Type;
             if(obj != null)
@@ -66,12 +71,13 @@ namespace GrobExp.Compiler.ExpressionEmitters
                     }
                 }
             }
-            var parameters = method.GetParameters();
+
+            var parametersArray = parameters.ToArray();
             var argumentsArray = arguments.ToArray();
             for(int i = 0; i < argumentsArray.Length; i++)
             {
                 var argument = argumentsArray[i];
-                var parameter = parameters[i];
+                var parameter = parametersArray[i];
                 if(parameter.ParameterType.IsByRef)
                 {
                     Type argumentType;


### PR DESCRIPTION
There are bugs in CallExpressionEmitter in case of processing an extension method call:

1. When `CompilerOptions.CheckNullReferences` enabled than null check statement applied to the first extension method argument. This behavior leads to the incorrect compilation of lambdas like this:
```C#
t => t.IsNull();
// With an extension method like this
public static bool IsNull(this string target) { return target == null; }
````
2. Usage of extension methods with `ref` parameters will break the compiler in some cases. This case little bit tricky and rare.

Pull request contains a simple patch for this two problems together with unit-tests for this bugs.